### PR TITLE
Support for twttr iOS App

### DIFF
--- a/Info.plist
+++ b/Info.plist
@@ -17,7 +17,10 @@
         <key>DDNotificationExternalProviderClasses</key>
         <dict>
             <key>DDNotificationTwitterContactPhotoProvider</key>
-            <string>com.atebits.Tweetie2</string>
+            <array>
+                <string>com.atebits.Tweetie2</string>
+                <string>com.twitter.twttr</string>
+            </array>
         </dict>
         <!-- 
         The ShortLook API version to use. This is to ensure that future updates with potentially


### PR DESCRIPTION
This PR adds the twttr bundle id (`com.twitter.twttr`) to this ShortLook provider since the twttr app uses the same `applicationUserInfo` in the notification.

**Note**: It seems like that the `DDNotificationExternalProviderClasses` doesn't accept the provider classes in arrays anymore. If I just provide the twttr bundle ID the tweak works fine but if I provide an array the method in `DDNotificationTwitterContactPhotoProvider` doesn't even get called anymore. So it seems like a bug in ShortLook itself to me.